### PR TITLE
[Feat/#51] getFetchWithSuspense 함수 구현

### DIFF
--- a/src/apis/getFetchWithSuspense.js
+++ b/src/apis/getFetchWithSuspense.js
@@ -1,0 +1,48 @@
+import axios from 'axios';
+
+const cache = {};
+
+const wrapPromise = promise => {
+  let status = 'pending';
+  let response;
+
+  const suspender = promise.then(
+    res => {
+      status = 'success';
+      response = res;
+    },
+    err => {
+      status = 'error';
+      response = err;
+    },
+  );
+
+  const read = () => {
+    switch (status) {
+      case 'pending':
+        throw suspender;
+      case 'error':
+        throw response;
+      default:
+        return response;
+    }
+  };
+  return { read };
+};
+
+const getFetchWithSuspense = url => {
+  if (!cache[url]) {
+    cache[url] = wrapPromise(
+      axios
+        .get(url)
+        .then(response => response.data)
+        .catch(error => {
+          return Promise.reject(error);
+        }),
+    );
+  }
+
+  return cache[url];
+};
+
+export { getFetchWithSuspense };

--- a/src/apis/index.js
+++ b/src/apis/index.js
@@ -1,1 +1,2 @@
 export const RIOT_API = 'https://asia.api.riotgames.com';
+export { getFetchWithSuspense } from './getFetchWithSuspense';

--- a/src/router/index.jsx
+++ b/src/router/index.jsx
@@ -9,5 +9,6 @@ export const router = createBrowserRouter([
   {
     path: '/:gameName/:tagLine',
     element: <MainPage />,
+    errorElement: <h1>Error</h1>,
   },
 ]);


### PR DESCRIPTION
## 개요
-  data fetch시 Suspense를 함께 사용할 수 있게 했습니다.

### 관련이슈
- #45 

## 사용방법
1. 데이터 호출
```
const TypeDescriptionCard = props => {
  const { imgSrc, title, description } = props;
  const gameName = '스망클고링';
  const tagLine = 'KR1';
  const url = `/riot/account/v1/accounts/by-riot-id/${gameName}/${tagLine}?api_key=${import.meta.env.VITE_RIOT_KEY}`;
  const response = getFetchWithSuspense(url).read();
  // 위처럼 getFetchWithSuspense에 url값을 넣고 호출해, read함수를 사용합니다.

 return {
   // rendering code...
  }
}
```
2. Suspense로 감싸기
데이터를 호출한 컴포넌트를 Suspense로 감싸줍니다.
```
<Suspense fallback={<h1>Loading TypeDescriptionCard</h1>}>
  <TypeDescriptionCard
      imgSrc={imageUrl}
      title={title}
      description={description}
   />
</Suspense>
```

## 기타
- 에러 발생 시에는 react-router의 errorElement로 이동되게 했습니다.
```
import { createBrowserRouter } from 'react-router-dom';
import { MainPage, SearchPage } from '../components/page';

export const router = createBrowserRouter([
  {
    path: '/',
    element: <SearchPage />,
  },
  {
    path: '/:gameName/:tagLine',
    element: <MainPage />,
    errorElement: <h1>Error</h1>,
  },
]);
```
- 필요하다면 추후에 errorBoundary 라이브러리를 이용해도 좋을 것 같습니다.
