### PR TITLE
[Feat/#55] 매치 정보를 기반으로 하는 사용자 유형을 출력 구현

### DIFF
--- a/src/apis/getStaticImage.js
+++ b/src/apis/getStaticImage.js
@@ -1,0 +1,5 @@
+const getStaticChampionImageUrl = championId => {
+  return `https://ddragon.leagueoflegends.com/cdn/img/champion/loading/${championId}_0.jpg`;
+};
+
+export { getStaticChampionImageUrl };

--- a/src/apis/index.js
+++ b/src/apis/index.js
@@ -1,2 +1,3 @@
 export const RIOT_API = 'https://asia.api.riotgames.com';
 export { getFetchWithSuspense } from './getFetchWithSuspense';
+export { getStaticChampionImageUrl } from './getStaticImage';

--- a/src/components/typeDescriptionCard/TypeDescriptionCard.jsx
+++ b/src/components/typeDescriptionCard/TypeDescriptionCard.jsx
@@ -1,24 +1,19 @@
 import { fontSize } from '@/theme';
 import * as S from '../style';
 import { getCharacter } from '../../utils';
-import { MATCH_INFO_LIST_ONE } from '../../constants';
-
-const imgSrc =
-  'https://ddragon.leagueoflegends.com/cdn/img/champion/loading/Amumu_0.jpg';
-const title = '자연은, 언제나 자신이 받은 것 이상으로 베푼다네.';
-const description =
-  '이 유형은 아군 정글에서 미니언을 처치하여 팀 자원을 적극적으로 활용하는 플레이 스타일을 의미합니다. 이 유형은 안정적인 성장과 게임의 리소스를 최대한 활용하여 팀의 전반적인 골드와 경험치를 증가시키는 전략을 사용합니다.';
+import { MATCH_INFO_LIST_ONE, MATCH_INFO_LIST } from '../../constants';
+import { getStaticChampionImageUrl } from '../../apis';
 
 const TypeDescriptionCard = props => {
-  console.log('TypeDescriptionCard');
   const { matchInfoList, puuid } = props;
-
-  getCharacter(MATCH_INFO_LIST_ONE, puuid);
+  const character = getCharacter(MATCH_INFO_LIST, puuid);
+  const { line = '', categoryDescription = '', characterId } = character;
+  const imageUrl = getStaticChampionImageUrl(characterId);
 
   return (
     <S.Card $width={'275px'}>
       <S.Flex $direction={'column'} $align={'center'}>
-        <S.Img src={imgSrc} $width={'275px'} $height={'477px'} />
+        <S.Img src={imageUrl} $width={'275px'} $height={'477px'} />
         <S.Padding $padding={['24px', '0px', '24px', '0px']}>
           <S.Text
             $fontSize={'24px'}
@@ -26,11 +21,11 @@ const TypeDescriptionCard = props => {
             $textAlign={'center'}
             $fontWeight={400}
           >
-            {title}
+            {line}
           </S.Text>
         </S.Padding>
         <S.Text $lineHeight={'150%'} $fontSize={fontSize.m}>
-          {description}
+          {categoryDescription}
         </S.Text>
       </S.Flex>
     </S.Card>

--- a/src/components/typeDescriptionCard/TypeDescriptionCard.jsx
+++ b/src/components/typeDescriptionCard/TypeDescriptionCard.jsx
@@ -6,7 +6,7 @@ import { getStaticChampionImageUrl } from '../../apis';
 
 const TypeDescriptionCard = props => {
   const { matchInfoList, puuid } = props;
-  const character = getCharacter(MATCH_INFO_LIST, puuid);
+  const character = getCharacter(MATCH_INFO_LIST, puuid); //api연결 시 MATCH_INFO_LIST가 아닌 props에서 받아온 matchInfoList 활용
   const { line = '', categoryDescription = '', characterId } = character;
   const imageUrl = getStaticChampionImageUrl(characterId);
 

--- a/src/utils/getCategory/categoryStatus.js
+++ b/src/utils/getCategory/categoryStatus.js
@@ -1,0 +1,214 @@
+import { CHARACTER_CATEGORY } from './characterCategory';
+import { getUserStatus, getUserTeamStatus } from '../getStatus';
+
+const createCategoryStat = ({
+  assists = '',
+  damageDealtToBuildings = '',
+  damageSelfMitigated = '',
+  detectorWardsPlaced = '',
+  goldEarned = '',
+  longestTimeSpentLiving = '',
+  neutralMinionsKilled = '', // 애도 함으로 나누면 안됨.
+  objectivesStolen = '', // 애도 함으로 나누면 안됨.
+  timeCCingOthers = '',
+  totalAllyJungleMinionsKilled = '',
+  totalDamageDealtToChampions = '',
+  totalDamageTaken = '',
+  totalEnemyJungleMinionsKilled = '',
+  totalHeal = '',
+  totalTimeSpentDead = '',
+  challenges: {
+    bountyGold = '', // 더 깊게
+    killingSprees = '', // 더 깊게 연속 킬수라 합으로 나누면 안됨. boolean
+  },
+}) => {
+  return {
+    assists,
+    damageDealtToBuildings,
+    damageSelfMitigated,
+    detectorWardsPlaced,
+    goldEarned,
+    longestTimeSpentLiving,
+    neutralMinionsKilled,
+    objectivesStolen,
+    timeCCingOthers,
+    totalAllyJungleMinionsKilled, // 합이 0일수도 있음.
+    totalDamageDealtToChampions,
+    totalDamageTaken,
+    totalEnemyJungleMinionsKilled,
+    totalHeal,
+    totalTimeSpentDead,
+    bountyGold,
+    killingSprees,
+  };
+};
+
+const addCategoryStatus = (obj1 = {}, obj2 = {}) => {
+  return {
+    assists: (obj1.assists || 0) + (obj2.assists || 0),
+    damageDealtToBuildings:
+      (obj1.damageDealtToBuildings || 0) + (obj2.damageDealtToBuildings || 0),
+    damageSelfMitigated:
+      (obj1.damageSelfMitigated || 0) + (obj2.damageSelfMitigated || 0),
+    detectorWardsPlaced:
+      (obj1.detectorWardsPlaced || 0) + (obj2.detectorWardsPlaced || 0),
+    goldEarned: (obj1.goldEarned || 0) + (obj2.goldEarned || 0),
+    longestTimeSpentLiving:
+      (obj1.longestTimeSpentLiving || 0) + (obj2.longestTimeSpentLiving || 0),
+    neutralMinionsKilled:
+      (obj1.neutralMinionsKilled || 0) + (obj2.neutralMinionsKilled || 0),
+    objectivesStolen:
+      (obj1.objectivesStolen || 0) + (obj2.objectivesStolen || 0),
+    timeCCingOthers: (obj1.timeCCingOthers || 0) + (obj2.timeCCingOthers || 0),
+    totalAllyJungleMinionsKilled:
+      (obj1.totalAllyJungleMinionsKilled || 0) +
+      (obj2.totalAllyJungleMinionsKilled || 0),
+    totalDamageDealtToChampions:
+      (obj1.totalDamageDealtToChampions || 0) +
+      (obj2.totalDamageDealtToChampions || 0),
+    totalDamageTaken:
+      (obj1.totalDamageTaken || 0) + (obj2.totalDamageTaken || 0),
+    totalEnemyJungleMinionsKilled:
+      (obj1.totalEnemyJungleMinionsKilled || 0) +
+      (obj2.totalEnemyJungleMinionsKilled || 0),
+    totalHeal: (obj1.totalHeal || 0) + (obj2.totalHeal || 0),
+    totalTimeSpentDead:
+      (obj1.totalTimeSpentDead || 0) + (obj2.totalTimeSpentDead || 0),
+    bountyGold: (obj1.bountyGold || 0) + (obj2.bountyGold || 0),
+    killingSprees: (obj1.killingSprees || 0) + (obj2.killingSprees || 0),
+  };
+};
+
+const divideCategoryStatus = (obj1 = {}, obj2 = {}) => {
+  const divide = (a, b) => (b ? a / b : a);
+
+  return {
+    assists: divide(obj1.assists || 0, obj2.assists || 1),
+    damageDealtToBuildings: divide(
+      obj1.damageDealtToBuildings || 0,
+      obj2.damageDealtToBuildings || 1,
+    ),
+    damageSelfMitigated: divide(
+      obj1.damageSelfMitigated || 0,
+      obj2.damageSelfMitigated || 1,
+    ),
+    detectorWardsPlaced: divide(
+      obj1.detectorWardsPlaced || 0,
+      obj2.detectorWardsPlaced || 1,
+    ),
+    goldEarned: divide(obj1.goldEarned || 0, obj2.goldEarned || 1),
+    longestTimeSpentLiving: divide(
+      obj1.longestTimeSpentLiving || 0,
+      obj2.longestTimeSpentLiving || 1,
+    ),
+    neutralMinionsKilled: divide(
+      obj1.neutralMinionsKilled || 0,
+      obj2.neutralMinionsKilled || 1,
+    ),
+    objectivesStolen: divide(
+      obj1.objectivesStolen || 0,
+      obj2.objectivesStolen || 1,
+    ),
+    timeCCingOthers: divide(
+      obj1.timeCCingOthers || 0,
+      obj2.timeCCingOthers || 1,
+    ),
+    totalAllyJungleMinionsKilled: divide(
+      obj1.totalAllyJungleMinionsKilled || 0,
+      obj2.totalAllyJungleMinionsKilled || 1,
+    ),
+    totalDamageDealtToChampions: divide(
+      obj1.totalDamageDealtToChampions || 0,
+      obj2.totalDamageDealtToChampions || 1,
+    ),
+    totalDamageTaken: divide(
+      obj1.totalDamageTaken || 0,
+      obj2.totalDamageTaken || 1,
+    ),
+    totalEnemyJungleMinionsKilled: divide(
+      obj1.totalEnemyJungleMinionsKilled || 0,
+      obj2.totalEnemyJungleMinionsKilled || 1,
+    ),
+    totalHeal: divide(obj1.totalHeal || 0, obj2.totalHeal || 1),
+    totalTimeSpentDead: divide(
+      obj1.totalTimeSpentDead || 0,
+      obj2.totalTimeSpentDead || 1,
+    ),
+    bountyGold: divide(obj1.bountyGold || 0, obj2.bountyGold || 1),
+    killingSprees: divide(obj1.killingSprees || 0, obj2.killingSprees || 1),
+  };
+};
+
+const findMaxStatAndCategory = (stats, categories) => {
+  let maxStat = -Infinity;
+  let maxStatKey = '';
+
+  for (const [key, value] of Object.entries(stats)) {
+    if (value > maxStat) {
+      maxStat = value;
+      maxStatKey = key;
+    }
+  }
+
+  const category = categories.find(category => {
+    const categoryMap = {
+      assists: 1,
+      bountyGold: 2,
+      damageDealtToBuildings: 3,
+      damageSelfMitigated: 4,
+      detectorWardsPlaced: 5,
+      goldEarned: 6,
+      killingSprees: 7,
+      longestTimeSpentLiving: 8,
+      neutralMinionsKilled: 9,
+      objectivesStolen: 10,
+      timeCCingOthers: 11,
+      totalAllyJungleMinionsKilled: 12,
+      totalDamageDealtToChampions: 13,
+      totalDamageTaken: 14,
+      totalEnemyJungleMinionsKilled: 15,
+      totalHeal: 16,
+      totalTimeSpentDead: 17,
+    };
+
+    return category.id === categoryMap[maxStatKey];
+  });
+
+  return category;
+};
+
+const getRatioStatus = (matchInfo, puuid) => {
+  // 1단계 해당하는 값들을 추출하기.(내 값, 팀 값)
+  const { teamId, status } = getUserStatus(matchInfo, puuid);
+  const coreStatus = createCategoryStat(status);
+
+  // 1단계 해당하는 값들을 추출하기.(팀 값)
+  const { teamStatusList } = getUserTeamStatus(matchInfo, teamId);
+  let totalTeamStatus = {};
+  for (const teamStatus of teamStatusList) {
+    const coreTeamStatus = createCategoryStat(teamStatus);
+    totalTeamStatus = addCategoryStatus(totalTeamStatus, coreTeamStatus);
+  }
+
+  // 2단계. 내 값/ 팀 값으로 비율 구하기.
+  const ratioStatus = divideCategoryStatus(coreStatus, totalTeamStatus);
+  return ratioStatus;
+};
+
+const getCharacter = (matchInfoList, puuid) => {
+  let userTotalMatchStatus = {};
+
+  for (const matchInfo of matchInfoList) {
+    const ratioStatus = getRatioStatus(matchInfo, puuid);
+    userTotalMatchStatus = addCategoryStatus(userTotalMatchStatus, ratioStatus);
+  }
+
+  const result = findMaxStatAndCategory(
+    userTotalMatchStatus,
+    CHARACTER_CATEGORY,
+  );
+
+  return result;
+};
+
+export { getCharacter };

--- a/src/utils/getCategory/characterCategory.js
+++ b/src/utils/getCategory/characterCategory.js
@@ -1,0 +1,137 @@
+const createCharacterCategory = ({
+  id = 0,
+  line = '',
+  categoryDescription = '',
+  characterId,
+}) => {
+  return {
+    id,
+    line,
+    categoryDescription,
+    characterId,
+  };
+};
+
+const CHARACTER_CATEGORY = [
+  createCharacterCategory({
+    id: 1,
+    line: '녀석들의 고통으로 우린 더 강해진다.',
+    categoryDescription:
+      '이 유형은 팀원들을 도와주는 데 특화되어 있습니다. 높은 어시스트 수는 협동심과 팀 플레이의 중요성을 나타내며, 팀 전투에서 중요한 역할을 맡고 있습니다.',
+    characterId: 'Thresh',
+  }),
+  createCharacterCategory({
+    id: 2,
+    line: '감수할 위험이 클수록 현상금도 많다.',
+    categoryDescription:
+      '이 유형은 적에게 위협적인 존재로 인식됩니다. 높은 현상금은 상대에게 많은 피해를 주거나 중요한 역할을 수행하고 있음을 의미합니다.',
+    characterId: 'MissFortune',
+  }),
+  createCharacterCategory({
+    id: 3,
+    line: '내 이론에 따르면 당신의 패배예요!',
+    categoryDescription:
+      '이 유형은 목표물을 파괴하는 데 강점이 있습니다. 타워나 억제기와 같은 구조물을 빠르게 파괴하여 팀의 승리에 기여합니다.',
+    characterId: 'Heimerdinger',
+  }),
+  createCharacterCategory({
+    id: 4,
+    line: '가장 듬직한 심장이 되어드리지.',
+    categoryDescription:
+      '이 유형은 피해를 흡수하고 생존하는 데 강점이 있습니다. 높은 생존력과 방어 능력으로 팀 전투에서 중요한 역할을 합니다.',
+    characterId: 'Braum',
+  }),
+  createCharacterCategory({
+    id: 5,
+    line: '정찰 다녀오겠습니다!',
+    categoryDescription:
+      '이 유형은 시야 장악에 뛰어납니다. 제어 와드를 많이 설치하여 팀에게 중요한 정보와 안전을 제공합니다.',
+    characterId: 'Teemo',
+  }),
+  createCharacterCategory({
+    id: 6,
+    line: '진정한 식욕은 사그라들지 않는 법.',
+    categoryDescription:
+      '이 유형은 많은 골드를 획득하여 아이템을 빠르게 구매할 수 있습니다. 이는 게임 중 강력한 영향력을 발휘하는 데 중요한 역할을 합니다.',
+    characterId: 'TahmKench',
+  }),
+  createCharacterCategory({
+    id: 7,
+    line: '학살의 현장에서 난, 피어오른다. 붉은 여명에 피어나는... 꽃처럼.',
+    categoryDescription:
+      '이 유형은 연속으로 적을 처치하는 데 강점이 있습니다. 높은 공격력과 정확한 플레이로 전투에서 큰 영향을 미칩니다.',
+    characterId: 'Jhin',
+  }),
+  createCharacterCategory({
+    id: 8,
+    line: '나 여깄지롱!”, “행운? 어... 실력이야.“',
+    categoryDescription:
+      '이 유형은 살아남는 것에 강점이 있습니다. 적에게 죽음을 당하지 않고 살아남아서 할 일을 하는 데 최적화되어 있죠!',
+    characterId: 'Ezreal',
+  }),
+  createCharacterCategory({
+    id: 9,
+    line: '피 흘릴 시간도 없어.',
+    categoryDescription:
+      '이 유형은 정글에서의 영향력이 큽니다. 중립 미니언을 많이 처치하여 팀에 중요한 자원을 제공합니다.',
+    characterId: 'Graves',
+  }),
+  createCharacterCategory({
+    id: 10,
+    line: '마술 하나 보여줄까!',
+    categoryDescription:
+      '이 유형은 중요한 오브젝트를 훔치는 데 특화되어 있습니다. 기습적인 플레이로 상대의 중요한 자원을 빼앗아옵니다.',
+    characterId: 'Shaco',
+  }),
+  createCharacterCategory({
+    id: 11,
+    line: '바위처럼 단단하게!',
+    categoryDescription:
+      '이 유형은 적에게 군중 제어(CC)를 가하는 데 뛰어납니다. 상대의 움직임을 제한하여 팀 전투에서 큰 영향을 미칩니다.',
+    characterId: 'Malphite',
+  }),
+  createCharacterCategory({
+    id: 12,
+    line: '자연은, 언제나 자신이 받은 것 이상으로 베푼다네.',
+    categoryDescription:
+      '이 유형은 아군 정글에서 미니언을 처치하여 팀 자원을 적극적으로 활용하는 플레이 스타일을 의미합니다. 이 유형은 안정적인 성장과 게임의 리소스를 최대한 활용하여 팀의 전반적인 골드와 경험치를 증가시키는 전략을 사용합니다.',
+    characterId: 'Ivern',
+  }),
+  createCharacterCategory({
+    id: 13,
+    line: '가만히 좀 있어봐, 총 좀 쏘게!',
+    categoryDescription:
+      '이 유형은 적 챔피언에게 큰 피해를 가하는 데 강점이 있습니다. 높은 공격력으로 전투에서 중요한 역할을 합니다.',
+    characterId: 'Jinx',
+  }),
+  createCharacterCategory({
+    id: 14,
+    line: '문도 머리에 메스 꽂혔는지 봐줄 사람?',
+    categoryDescription:
+      '이 유형은 많은 피해를 흡수하는 데 특화되어 있습니다. 팀 전투에서 적의 공격을 막아내며 팀원을 보호합니다.',
+    characterId: 'DrMundo',
+  }),
+  createCharacterCategory({
+    id: 15,
+    line: '날 두려워 하는게 당연해.',
+    categoryDescription:
+      '이 유형은 상대 정글에 대한 압박이 뛰어납니다. 적 정글 미니언을 처치하여 상대의 자원을 빼앗고 억제합니다.',
+    characterId: 'Nidalee',
+  }),
+  createCharacterCategory({
+    id: 16,
+    line: '당신을 치유하고 지켜드리겠어요.',
+    categoryDescription:
+      '이 유형은 팀원들을 치유하는 데 특화되어 있습니다. 높은 치유량으로 팀의 생존력을 크게 향상시킵니다.',
+    characterId: 'Soraka',
+  }),
+  createCharacterCategory({
+    id: 17,
+    line: '죽음은 바람과 같지. 늘 내 곁에 있으니.',
+    categoryDescription:
+      '이 유형은 상대적으로 죽음의 빈도가 높습니다. 이는 공격적인 플레이 스타일이나 높은 리스크를 감수하는 플레이를 의미할 수 있습니다.',
+    characterId: 'Yasuo',
+  }),
+];
+
+export { CHARACTER_CATEGORY };

--- a/src/utils/getStatus.js
+++ b/src/utils/getStatus.js
@@ -1,0 +1,32 @@
+// 내 스탯을 가져오는 함수.
+const getUserStatus = (matchInfo, userPuuid) => {
+  let myStatusIndex = -1;
+  const puuidList = matchInfo.metadata.participants;
+
+  puuidList.forEach((puuid, index) => {
+    if (puuid === userPuuid) {
+      myStatusIndex = index;
+    }
+  });
+
+  const status = matchInfo.info.participants[myStatusIndex];
+  const teamId = status.teamId;
+
+  return { teamId, status };
+};
+
+// 내 팀의 정보를 반환하는 함수.
+const getUserTeamStatus = (matchInfo, teamId) => {
+  const teamStatusList = [];
+  const participantList = matchInfo.info.participants;
+
+  participantList.forEach(participant => {
+    if (participant.teamId === teamId) {
+      teamStatusList.push(participant);
+    }
+  });
+
+  return { teamStatusList };
+};
+
+export { getUserStatus, getUserTeamStatus };

--- a/src/utils/index.js
+++ b/src/utils/index.js
@@ -1,1 +1,2 @@
-export { getCharacter } from './getCharacter';
+export { getCharacter } from './getCategory/categoryStatus';
+export { getUserStatus, getUserTeamStatus } from './getStatus';


### PR DESCRIPTION
## 개요
- matchInfo를 바탕으로 데이터를 가공해 유형화한 뒤, 사용자와 가장 유사한 유형을 보여주는 기능을 구현했습니다.

### 관련이슈
- #45
- #58 

## 변경로직
```
// src/utils/getStatus.js
export { getUserStatus, getUserTeamStatus };
```
기존의 src/utiils/getCharacter.js 에 위치하던 함수의 위치를 변경했습니다. 기존의 카테고리에서만 사용되던 함수를 사용자의 업적(#57 )이나 사용자의 이름 앞 수식어를 붙일 때도 사용할 수 있게 분리했습니다.

